### PR TITLE
Rework: new convert() API, higher performance, remember preferred unit exactly

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,40 @@ Based on [PQM](https://github.com/GhostWrench/pqm), with extensive changes.
 
 MIT licensed.
 
-Zero dependencies.
+## Features
+
+- Zero dependencies.
+- Only 4.5 KiB minified and gzipped.
+- Basic math operations: multiply, add, subtract, etc.
+- Supports tolerance values like "2±0.2 cm", and carries them through mathematical operations.
+- "Remembers" the units you input and uses them by default for output.
+- Metric prefixes for all SI units (e.g. km, MHz, μN)
+- Binary prefixes for all information units (e.g. kib, kiB, MiB)
+- Custom dimensions ("2 foo" times "6 bar" = "12 foo⋅bar") can be defined on the fly
+- Temperature units: K (Kelvins), degC (Celcius measurement), deltaC (Celcius difference), degF (Fahrenheit measurement)
+- Supports "%" (percent) as a unit (50% of 50% is 25%, not "0.25 % %"; 50% of 400g is 200g, not "20000 g %")
+- Faster than any comparable libraries for its feature set (you can run [the benchmark](./tests/benchmark.bench.ts)
+  yourself with `deno bench`):
+  - Quantity conversions:
+    - 1.1x faster than `PQM`
+    - 1.6x faster than `mathjs`
+    - 2.1x faster than `unitmath`
+    - 3.0x faster than `js-quantities`
+  - Custom dimensions
+    - 1.2x faster than `mathjs`
+    - 1.9x faster than `unitmath`
+    - `PQM` and `js-quantities` don't support custom dimensions
+
+## Missing Features
+
+- Some mathematical operations (e.g. division, sqrt) are not implemented yet because I didn't need them yet - feel free
+  to add them.
+- Some units are not supported because I didn't need them yet - feel free to add them (e.g. radiation, luminosity, tsp,
+  oz).
+- Array/vector operations (do math with many similar unit values efficiently) are not supported.
+- Handling of "significant figures" is only partially implemented and needs improvement.
+- This library generally tries _not_ to support units that can be considered deprecated (like "bar", "dram", "furlong",
+  "league", "poise", etc.) or that are ambiguous (like "ton", "gallon", etc.).
 
 ## Installation
 
@@ -109,19 +142,6 @@ const fb = f.multiply(b);
 fb.toString(); // "20 _foo⋅_bar"
 fb.multiply(f).toString(); // "200 _foo^2⋅_bar"
 ```
-
-## Development Roadmap / TODOs
-
-- Finish implementing "significant digits"
-- Implement more mathematical operations like division and exponentiation.
-- Add support for angular units, including converting radians to degrees and treating "angle" as a dimension, to avoid
-  ambiguities with units like "rpm" and "Hz".
-- Consider adding support for additional units (radiation, angles, more non-SI units).
-
-## Non-features / Non-goals
-
-This library generally tries _not_ to support units that can be considered deprecated (like "bar", "dram", "furlong",
-"league", "poise", etc.) or that are ambiguous (like "ton", "gallon", etc.).
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -30,20 +30,24 @@ Zero dependencies.
 Importing:
 
 ```ts
-import { Quantity } from "@bradenmacdonald/quantity-math-js";
+import { Q, Quantity } from "@bradenmacdonald/quantity-math-js";
 ```
 
 Constructing a quantity value:
 
 ```ts
 new Quantity(10, { units: "cm" });
+// or
+Q`10 cm`;
+// or
+Q("10 cm");
 ```
 
 Adding two quantities:
 
 ```ts
-const x = new Quantity(5, { units: "m" });
-const y = new Quantity(20, { units: "cm" });
+const x = Q`5 m`;
+const y = Q`20 cm`;
 const z = x.add(y);
 z.toString(); // "5.2 m"
 ```
@@ -51,8 +55,8 @@ z.toString(); // "5.2 m"
 Multiplying two quantities:
 
 ```ts
-const x = new Quantity(5, { units: "kg" });
-const y = new Quantity(2, { units: "m" });
+const x = Q`5 kg`;
+const y = Q`2 m`;
 const z = x.multiply(y);
 z.toString(); // "10 kg⋅m"
 ```
@@ -64,37 +68,19 @@ const x = new Quantity(5, { units: "lb" });
 x.get(); // { magnitude: 5, units: "lb" }
 ```
 
-Serialize to simple object, using specified units:
+Convert a quantity to the specified units:
 
 ```ts
-const x = new Quantity(10, { units: "cm" });
-x.getWithUnits("in"); // { magnitude: 3.9370078740157486, units: "in" }
+const x = Q`10 cm`;
+x.convert("in").get(); // { magnitude: 3.9370078740157486, units: "in" }
+x.convert("mm").toString(); // "100 mm"
 ```
 
 Simplify units:
 
 ```ts
 const x = new Quantity(5, { units: "kg^2⋅m^2⋅s^-4⋅A^-2" });
-x.getSI(); // { magnitude: 5, units: "kg/F" }
-```
-
-## Syntactic Sugar
-
-If you prefer, there is a much more compact way to initialize `Quantity` instances: using the `Q` template helper. This
-is slightly less efficient, but far more readable and convenient in many cases.
-
-```ts
-import { Q } from "@bradenmacdonald/quantity-math-js";
-
-const force = Q`34.2 kg m/s^2`; // Shorter version of: new Quantity(34.2, {units: "kg m/s^2"})
-force.getSI(); // { magnitude: 34.2, units: "N" }
-force.multiply(Q`2 s^2`).toString(); // "68.4 kg⋅m"
-```
-
-You can also call it as a function, which acts like "parse quantity string":
-
-```ts
-const force = Q("34.2 kg m/s^2"); // new Quantity(34.2, {units: "kg m/s^2"})
+x.toSI().toString(); // "5 kg/F"
 ```
 
 ## Error/uncertainty/tolerance

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,14 +5,16 @@
     "version": "1.0.1",
     "fmt": {
         "indentWidth": 4,
-        "lineWidth": 120
+        "lineWidth": 120,
+        "exclude": ["tests/mod.min.js"]
     },
     "lint": {
         "rules": {
             // Unfortunately we need "slow types" in units.ts for now.
             // https://github.com/jsr-io/jsr/issues/155
             "exclude": ["no-slow-types"]
-        }
+        },
+        "exclude": ["tests/mod.min.js"]
     },
     "imports": {
         "@std/assert": "jsr:@std/assert@^0.218",

--- a/dimensions.ts
+++ b/dimensions.ts
@@ -66,8 +66,7 @@ export class Dimensions {
 
     /** Is this dimensionless? (all dimensions are zero) */
     public get isDimensionless(): boolean {
-        if (this.#cachedDimensionality !== undefined) return this.#cachedDimensionality === 0;
-        return this.dimensions.every((d) => d === 0);
+        return this.dimensionality === 0;
     }
 
     /** Private cache of the dimensionality, as an optimization */
@@ -82,15 +81,9 @@ export class Dimensions {
     }
 
     private static combineCustomDimensionNames(x: Dimensions, y: Dimensions) {
-        const customDimensionNames = [...x.customDimensionNames];
-        for (const custDimName of y.customDimensionNames) {
-            if (!customDimensionNames.includes(custDimName)) {
-                customDimensionNames.push(custDimName);
-            }
-        }
+        const set = new Set([...x.customDimensionNames, ...y.customDimensionNames]);
         // Custom dimension names must always be sorted.
-        customDimensionNames.sort();
-        return customDimensionNames;
+        return Array.from(set).sort();
     }
 
     /**

--- a/dimensions.ts
+++ b/dimensions.ts
@@ -2,12 +2,12 @@ import { QuantityError } from "./error.ts";
 
 /**
  * How many basic dimensions there are
- * (mass, length, time, temp, current, substance, luminosity, information)
+ * (mass, length, time, temp, current, substance, information, reserved)
  *
  * As opposed to custom dimensions, like "flurbs per bloop" which has two
  * custom dimensions (flurbs and bloops).
  */
-const numBasicDimensions = 9;
+const numBasicDimensions = 8;
 
 const emptyArray = Object.freeze([]);
 
@@ -32,16 +32,15 @@ export class Dimensions {
             temperature: number,
             current: number,
             substance: number,
-            luminosity: number,
             information: number,
-            angle: number,
+            reserved: number, // for luminosity or angle or ?
             /**
              * Track custom dimensions.
              *
              * For special units like "passengers per hour per direction", "passengers" is a custom dimension, as is "direction"
              */
             ...customDimensions: number[],
-        ] & { length: 9 | 10 | 11 | 12 | 13 },
+        ] & { length: 8 | 10 | 9 | 11 | 12 },
         /** names of the custom dimensions, e.g. "fish", "passengers", "$USD", if relevant */
         public readonly customDimensionNames: readonly string[] = emptyArray,
     ) {
@@ -219,4 +218,4 @@ export class Dimensions {
  *
  * Likewise an SI expression like "1 μm/m" is dimensionless after simplification.
  */
-export const Dimensionless: Dimensions = new Dimensions([0, 0, 0, 0, 0, 0, 0, 0, 0]);
+export const Dimensionless: Dimensions = new Dimensions([0, 0, 0, 0, 0, 0, 0, 0]);

--- a/error.ts
+++ b/error.ts
@@ -1,2 +1,13 @@
 /** Base class for all errors thrown by quantity-math-js */
 export class QuantityError extends Error {}
+
+/**
+ * The requested conversion is not possible/valid.
+ *
+ * e.g. converting meters to seconds.
+ */
+export class InvalidConversionError extends QuantityError {
+    constructor() {
+        super("Cannot convert units that aren't compatible.");
+    }
+}

--- a/mod.ts
+++ b/mod.ts
@@ -7,5 +7,5 @@
 export { Quantity, type SerializedQuantity } from "./quantity.ts";
 export { Q } from "./q.ts";
 export { builtInUnits, type ParsedUnit, parseUnits, type Unit } from "./units.ts";
-export { QuantityError } from "./error.ts";
+export { InvalidConversionError, QuantityError } from "./error.ts";
 export { Dimensionless, Dimensions } from "./dimensions.ts";

--- a/q.ts
+++ b/q.ts
@@ -1,7 +1,7 @@
 import { Quantity } from "./quantity.ts";
 import { QuantityError } from "./error.ts";
 
-export function Q(strings: string | ReadonlyArray<string>, ...keys: unknown[]): Quantity {
+export function Q(strings: string | readonly string[], ...keys: unknown[]): Quantity {
     let fullString: string;
     if (typeof strings == "string") {
         fullString = strings;

--- a/q.ts
+++ b/q.ts
@@ -1,6 +1,9 @@
 import { Quantity } from "./quantity.ts";
 import { QuantityError } from "./error.ts";
 
+/**
+ * Construct a `Quantity` instance from a string.
+ */
 export function Q(strings: string | readonly string[], ...keys: unknown[]): Quantity {
     let fullString: string;
     if (typeof strings == "string") {

--- a/q.ts
+++ b/q.ts
@@ -1,4 +1,5 @@
-import { Quantity, QuantityError } from "@bradenmacdonald/quantity-math-js";
+import { Quantity } from "./quantity.ts";
+import { QuantityError } from "./error.ts";
 
 export function Q(strings: string | ReadonlyArray<string>, ...keys: unknown[]): Quantity {
     let fullString: string;

--- a/quantity.ts
+++ b/quantity.ts
@@ -396,9 +396,9 @@ export class Quantity {
             let bestIdx = -1;
             let bestInv = 0;
             let bestRemainder = remainder;
+            unitsLoop:
             for (let unitIdx = 0; unitIdx < unitArray.length; unitIdx++) {
                 const unitDimensions = unitArray[unitIdx];
-                if (unitDimensions.isDimensionless) continue; // skip dimensionless units
                 for (let isInv = 1; isInv >= -1; isInv -= 2) {
                     const newRemainder = remainder.multiply(isInv === 1 ? unitDimensions.invert() : unitDimensions);
                     // If this unit reduces the dimensionality more than the best candidate unit yet found,
@@ -410,7 +410,10 @@ export class Quantity {
                         bestIdx = unitIdx;
                         bestInv = isInv;
                         bestRemainder = newRemainder;
-                        break; // Tiny optimization: if this unit is better than bestRemainder, we don't need to check its inverse
+                        // If we've matched all the dimensions, there's no need to check more units.
+                        if (newRemainder.isDimensionless && isInv === 1) break unitsLoop;
+                        // Otherwise, if this unit is better than bestRemainder, we don't need to check its inverse
+                        break;
                     }
                 }
             }

--- a/quantity.ts
+++ b/quantity.ts
@@ -419,7 +419,7 @@ export class Quantity {
             }
             // Check to make sure that progress is being made towards remainder = 0
             // If no more progress is being made then we won't be able to find a compatible unit set from this list.
-            if (bestRemainder.dimensionality >= remainder.dimensionality) {
+            if (bestIdx === -1) {
                 throw new InvalidConversionError();
             }
             // Check if the new best unit already in the set of numerator or

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+mod.min.js

--- a/tests/advanced-custom.test.ts
+++ b/tests/advanced-custom.test.ts
@@ -26,7 +26,7 @@ Deno.test("Units with 'custom' dimensions", async (t) => {
             const q = new Quantity(3400, { units: "pphpd" });
             assertEquals(
                 q.dimensions,
-                new Dimensions([0, 0, -1, 0, 0, 0, 0, 0, 0, -1, 1], [
+                new Dimensions([0, 0, -1, 0, 0, 0, 0, 0, -1, 1], [
                     "dir",
                     "pax",
                 ]),
@@ -67,7 +67,7 @@ Deno.test("Units with 'custom' dimensions", async (t) => {
                 magnitude: 3_400,
                 units: "pphpd⋅day",
             });
-            assertEquals(product.getWithUnits(`_pax/_dir`), {
+            assertEquals(product.convert(`_pax/_dir`).get(), {
                 magnitude: 3_400 * 24,
                 units: "_pax/_dir",
             });

--- a/tests/benchmark.bench.ts
+++ b/tests/benchmark.bench.ts
@@ -13,13 +13,13 @@ Deno.bench("Quantity conversions - quantity-math-js", { group: "conversion", bas
     const e = d.multiply(Q`0.1 s^-1`); // 1 kg * m / s^2 (= 1 N)
     const f = e.add(Q`5.5 N`);
     const g = f.multiply(Q`10`).add(Q`5 N`).add(Q`-20 N`).multiply(Q`2`);
-    const h = g.getSI();
-    if (`${h.magnitude} ${h.units}` !== "100 N") throw new Error(`Got ${h.toString()} unexpectedly.`);
+    const h = g.toSI();
+    if (h.toString() !== "100 N") throw new Error(`Got ${h.toString()} unexpectedly.`);
 
     // And some crazy conversion:
     const orig = Q`500 uF`;
-    const converted = orig.getWithUnits("h⋅s^3⋅A^2/lb⋅m⋅ft");
-    if (`${converted.magnitude} ${converted.units}` !== "1.920207699666667e-8 h⋅s^3⋅A^2/lb⋅m⋅ft") {
+    const converted = orig.convert("h⋅s^3⋅A^2/lb⋅m⋅ft");
+    if (converted.toString() !== "1.920207699666667e-8 h⋅s^3⋅A^2/lb⋅m⋅ft") {
         throw new Error(`Got ${converted.toString()} unexpectedly.`);
     }
 });

--- a/tests/benchmark.bench.ts
+++ b/tests/benchmark.bench.ts
@@ -2,6 +2,7 @@ import { Q as ourQ } from "../mod.ts";
 
 import JSQ_Qty from "npm:js-quantities@1.8.0";
 import PQM from "npm:pqm@1.0.0";
+import * as mathjs from "npm:mathjs@12.4.1";
 
 Deno.bench("Quantity conversions - quantity-math-js", { group: "conversion", baseline: true }, () => {
     const Q = ourQ;
@@ -65,4 +66,63 @@ Deno.bench("Quantity conversions - PQM", { group: "conversion" }, () => {
     if (converted.toString() !== "1.920207699666667e-8") {
         throw new Error(`Got ${converted.toString()} unexpectedly.`);
     }
+});
+
+Deno.bench("Quantity conversions - mathjs", { group: "conversion" }, () => {
+    const Q = mathjs.unit;
+    const a = Q(400, `g`);
+    const b = Q("0.5"); // Can't find a way to do "50 %" in mathjs ?
+    const c = a.multiply(b);
+    const d = c.multiply(Q(50, `m/s`)); // 10,000 g * m / s (= 10 kg * m / s)
+    const e = d.multiply(Q(0.1, `s^-1`)); // 1 kg * m / s^2 (= 1 N)
+    const f = mathjs.add(e, Q(5.5, `N`));
+    const g = mathjs.add(mathjs.add(f.multiply(Q("10")), Q(5, `N`)), Q(-20, `N`)).multiply(Q("2"));
+    const h = g.toSI();
+    // This library won't simplify to Newtons, since it's technically a derived unit.
+    if (h.toString() !== "100 (kg m) / s^2") throw new Error(`Got ${h.toString()} unexpectedly.`);
+
+    // And some crazy conversion:
+    const orig = Q(500, `uF`);
+    const converted = orig.to("hr s^3 A^2/(lbm m ft)");
+    if (converted.toString() !== "1.9202076996666667e-8 (hr s^3 A^2) / (lbm m ft)") {
+        throw new Error(`Got ${converted.toString()} unexpectedly.`);
+    }
+});
+
+Deno.bench("Custom units - quantity-math-js", { group: "custom", baseline: true }, () => {
+    const Q = ourQ;
+    const a = Q`400 _fleeb`;
+    const b = Q`50 %`;
+    const c = a.multiply(b); // 200 _fleeb
+    const d = c.multiply(Q`50 _bil/_boop`); // 10,000 _fleeb _bil / _boop
+    const e = d.multiply(Q`0.1 s^-1`); // 1,000 _fleeb _bil / _boop s
+    const f = e.add(Q`500 _fleeb _bil / _boop s`); // 1,500 _fleeb _bil / _boop s
+    const g = f.multiply(Q`10`).add(Q`5 _fleeb _bil / _boop s`).add(Q`-20 _fleeb _bil / _boop s`).multiply(Q`2`);
+    if (g.toString() !== "29970 _fleeb⋅_bil/_boop⋅s") throw new Error(`Got ${g.toString()} unexpectedly.`);
+
+    const h = g.multiply(Q`0.1 _schleem`).sub(Q`997 _fleeb _schleem _bil / _boop s`).multiply(Q`1 _boop / _bil`);
+    if (h.toString() !== "2000 _fleeb⋅_schleem/s") throw new Error(`Got ${h.toString()} unexpectedly.`);
+});
+
+mathjs.createUnit("fleeb");
+mathjs.createUnit("bil");
+mathjs.createUnit("boop");
+mathjs.createUnit("schleem");
+
+Deno.bench("Custom units - math-js", { group: "custom" }, () => {
+    const Q = mathjs.unit;
+    const a = Q(`400 fleeb`);
+    const b = Q("0.5"); // Can't find a way to do "50 %" in mathjs ?
+    const c = a.multiply(b); // 200 fleeb
+    const d = c.multiply(Q(`50 bil/boop`)); // 10,000 fleeb bil / boop
+    const e = d.multiply(Q(`0.1 s^-1`)); // 1,000 fleeb bil / boop s
+    const f = mathjs.add(e, Q(`500 fleeb bil / (boop s)`)); // 1,500 fleeb bil / boop s
+    const g = mathjs.add(mathjs.add(f.multiply(Q(`10`)), Q(`5 fleeb bil / (boop s)`)), Q(`-20 fleeb bil / (boop s)`))
+        .multiply(Q(`2`));
+    if (g.toString() !== "29970 (fleeb bil) / (boop s)") throw new Error(`Got ${g.toString()} unexpectedly.`);
+
+    const h = mathjs.subtract(g.multiply(Q(`0.1 schleem`)), Q(`997 fleeb schleem bil / (boop s)`)).multiply(
+        Q(`1 boop / bil`),
+    );
+    if (h.toString() !== "2000 (fleeb schleem) / s") throw new Error(`Got ${h.toString()} unexpectedly.`);
 });

--- a/tests/bundle-size.ts
+++ b/tests/bundle-size.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env deno run --allow-read --allow-env --allow-net --allow-write --allow-run
+/**
+ * This tool allows a quick way to measure the size of the minified, .gzipped bundle
+ * of quantity-math-js. Just run it (it's marked as executable).
+ */
+import * as esbuild from "https://deno.land/x/esbuild@v0.20.1/mod.js";
+
+const testsDir = import.meta.dirname + "/";
+const outFile = `${testsDir}/mod.min.js`;
+
+await esbuild.build({
+    entryPoints: ["mod.ts"],
+    bundle: true,
+    minify: true,
+    target: "es2020",
+    outfile: outFile,
+    format: "esm",
+});
+console.log("Created mod.min.js");
+console.log("Validating it...");
+const { Q } = await import(outFile);
+if (Q`10 m`.add(Q(`15 cm`)).toString() !== "10.15 m") {
+    throw new Error("Minified version doesn't work.");
+}
+const minifiedSource = await Deno.readFile(outFile);
+const minifiedSizeQ = Q(`${minifiedSource.byteLength} B`);
+console.log(`Size: ${minifiedSizeQ.convert("KiB").toString()}`);
+
+// GZip
+const instream = ReadableStream.from([minifiedSource]).pipeThrough(new CompressionStream("gzip"));
+let gzippedSize = 0;
+for await (const chunk of instream) {
+    gzippedSize += chunk.byteLength;
+}
+const gzippedSizeQ = Q(`${gzippedSize} B`);
+console.log(`Size: ${gzippedSizeQ.convert("KiB").toString()}`);

--- a/tests/dimensions.test.ts
+++ b/tests/dimensions.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertThrows } from "@std/assert";
 import { Dimensions, QuantityError } from "../mod.ts";
 
-const baseDimensions = [0, 0, 0, 0, 0, 0, 0, 0, 0] as const;
+const baseDimensions = [0, 0, 0, 0, 0, 0, 0, 0] as const;
 
 Deno.test(`Dimensions constructor`, async (t) => {
     await t.step(
@@ -19,14 +19,14 @@ Deno.test(`Dimensions constructor`, async (t) => {
             assertThrows(
                 () => {
                     // @ts-expect-error: array has too few entries
-                    new Dimensions([1, 2, 3, 4, 5, 6, 7, 8]);
+                    new Dimensions([1, 2, 3, 4, 5, 6, 7]);
                 },
                 QuantityError,
                 "not enough dimensions specified for Quantity.",
             );
 
             // This one throws no error:
-            new Dimensions([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+            new Dimensions([1, 2, 3, 4, 5, 6, 7, 8]);
         },
     );
 
@@ -127,18 +127,18 @@ Deno.test(`Multiplying custom dimensions`, async (t) => {
 
 Deno.test(`toString`, async (t) => {
     await t.step(`dimensionless`, () => {
-        assertEquals(new Dimensions([...baseDimensions]).toString(), "[0,0,0,0,0,0,0,0,0]");
+        assertEquals(new Dimensions([...baseDimensions]).toString(), "[0,0,0,0,0,0,0,0]");
     });
-    await t.step(`[0,2,4,6,8,0,0,0,-3]`, () => {
-        assertEquals(new Dimensions([0, 2, 4, 6, 8, 0, 0, 0, -3]).toString(), "[0,2,4,6,8,0,0,0,-3]");
+    await t.step(`[0,2,4,6,8,0,0,-3]`, () => {
+        assertEquals(new Dimensions([0, 2, 4, 6, 8, 0, 0, -3]).toString(), "[0,2,4,6,8,0,0,-3]");
     });
-    await t.step(`[0,2,4,6,8,0,0,0,-3,7] with 7 in a custom "foo" dimension`, () => {
-        assertEquals(new Dimensions([0, 2, 4, 6, 8, 0, 0, 0, -3, 7], ["foo"]).toString(), "[0,2,4,6,8,0,0,0,-3,foo:7]");
+    await t.step(`[0,2,4,6,8,0,0,-3,7] with 7 in a custom "foo" dimension`, () => {
+        assertEquals(new Dimensions([0, 2, 4, 6, 8, 0, 0, -3, 7], ["foo"]).toString(), "[0,2,4,6,8,0,0,-3,foo:7]");
     });
     await t.step(`different custom dimensions (4)`, () => {
         assertEquals(
             new Dimensions([...baseDimensions, 1, 2, 0, -3], ["abc", "bar", "foo", "zzzzzzz"]).toString(),
-            "[0,0,0,0,0,0,0,0,0,abc:1,bar:2,foo:0,zzzzzzz:-3]",
+            "[0,0,0,0,0,0,0,0,abc:1,bar:2,foo:0,zzzzzzz:-3]",
         );
     });
 });

--- a/tests/quantity.test.ts
+++ b/tests/quantity.test.ts
@@ -261,6 +261,7 @@ Deno.test("Multiplying quantities", async (t) => {
         const z = x.multiply(y);
         assertEquals(z.magnitude, 15);
         assertEquals(z.dimensions, TWO_LENGTH_DIMENSIONS); // m²
+        assertEquals(z.toString(), "15 m^2");
     });
     await t.step(`(50 %) * (50 %)`, () => {
         const x = new Quantity(50, { units: "%" });
@@ -271,6 +272,12 @@ Deno.test("Multiplying quantities", async (t) => {
     await t.step(`(50 %) * (400 g)`, () => {
         const x = new Quantity(50, { units: "%" });
         const y = new Quantity(400, { units: "g" });
+        const z = x.multiply(y);
+        assertEquals(z.toString(), "200 g");
+    });
+    await t.step(`(400 g) * (50 %)`, () => {
+        const x = new Quantity(400, { units: "g" });
+        const y = new Quantity(50, { units: "%" });
         const z = x.multiply(y);
         assertEquals(z.toString(), "200 g");
     });

--- a/tests/quantity.test.ts
+++ b/tests/quantity.test.ts
@@ -1,13 +1,13 @@
 import { assert, assertEquals, assertFalse, assertNotEquals, assertThrows } from "@std/assert";
 import { Dimensions, Quantity, QuantityError } from "../mod.ts";
 
-const ONE_MASS_DIMENSION = new Dimensions([1, 0, 0, 0, 0, 0, 0, 0, 0]);
-const ONE_LENGTH_DIMENSION = new Dimensions([0, 1, 0, 0, 0, 0, 0, 0, 0]);
-const ONE_TEMP_DIMENSION = new Dimensions([0, 0, 0, 1, 0, 0, 0, 0, 0]);
-const TWO_LENGTH_DIMENSIONS = new Dimensions([0, 2, 0, 0, 0, 0, 0, 0, 0]);
-const THREE_LENGTH_DIMENSIONS = new Dimensions([0, 3, 0, 0, 0, 0, 0, 0, 0]);
+const ONE_MASS_DIMENSION = new Dimensions([1, 0, 0, 0, 0, 0, 0, 0]);
+const ONE_LENGTH_DIMENSION = new Dimensions([0, 1, 0, 0, 0, 0, 0, 0]);
+const ONE_TEMP_DIMENSION = new Dimensions([0, 0, 0, 1, 0, 0, 0, 0]);
+const TWO_LENGTH_DIMENSIONS = new Dimensions([0, 2, 0, 0, 0, 0, 0, 0]);
+const THREE_LENGTH_DIMENSIONS = new Dimensions([0, 3, 0, 0, 0, 0, 0, 0]);
 /** Force is mass*length/time^2 */
-const FORCE_DIMENSIONS = new Dimensions([1, 1, -2, 0, 0, 0, 0, 0, 0]);
+const FORCE_DIMENSIONS = new Dimensions([1, 1, -2, 0, 0, 0, 0, 0]);
 
 Deno.test("Quantity instance equality", async (t) => {
     /**
@@ -53,31 +53,31 @@ Deno.test("Quantity instance equality", async (t) => {
     await check(
         "Different dimensions, same magnitude",
         // This one will equal itself:
-        () => new Quantity(15, { dimensions: new Dimensions([1, 0, 0, 0, 0, 0, 0, 0, 0]) }),
+        () => new Quantity(15, { dimensions: new Dimensions([1, 0, 0, 0, 0, 0, 0, 0]) }),
         // But the one above won't equal this one, with different dimensions:
-        () => new Quantity(15, { dimensions: new Dimensions([0, 1, 0, 0, 0, 0, 0, 0, 0]) }),
+        () => new Quantity(15, { dimensions: new Dimensions([0, 1, 0, 0, 0, 0, 0, 0]) }),
     );
     await check(
         "Different dimensions, same magnitude (2)",
-        () => new Quantity(0, { dimensions: new Dimensions([1, 0, 0, 0, 0, 0, 0, 0, 0]) }),
-        () => new Quantity(0, { dimensions: new Dimensions([0, 0, 0, 0, 0, 0, 0, 0, 0]) }),
+        () => new Quantity(0, { dimensions: new Dimensions([1, 0, 0, 0, 0, 0, 0, 0]) }),
+        () => new Quantity(0, { dimensions: new Dimensions([0, 0, 0, 0, 0, 0, 0, 0]) }),
     );
     await check(
         "Different dimensions, same magnitude (3)",
-        () => new Quantity(-10, { dimensions: new Dimensions([1, 0, 0, 1, 2, 0, 0, 0, 0]) }),
-        () => new Quantity(-10, { dimensions: new Dimensions([1, 0, 0, 1, 1, 0, 0, 0, 0]) }),
+        () => new Quantity(-10, { dimensions: new Dimensions([1, 0, 0, 1, 2, 0, 0, 0]) }),
+        () => new Quantity(-10, { dimensions: new Dimensions([1, 0, 0, 1, 1, 0, 0, 0]) }),
     );
     await check(
         "Different custom dimensions, same magnitude and regular dimensions",
         () =>
             new Quantity(-10, {
                 // deno-fmt-ignore
-                dimensions: new Dimensions([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1], ["a", "b", "c", "d"]),
+                dimensions: new Dimensions([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1], ["a", "b", "c", "d"]),
             }),
         () =>
             new Quantity(-10, {
                 dimensions: new Dimensions(
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                     ["a", "b", "c", "d"],
                 ),
             }),
@@ -87,14 +87,14 @@ Deno.test("Quantity instance equality", async (t) => {
         () =>
             new Quantity(-10, {
                 dimensions: new Dimensions(
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2],
                     ["a", "b", "c", "d"],
                 ),
             }),
         () =>
             new Quantity(-10, {
                 dimensions: new Dimensions(
-                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2],
+                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2],
                     ["a", "b", "c", "elf"],
                 ),
             }),

--- a/units.ts
+++ b/units.ts
@@ -59,17 +59,17 @@ export interface Unit {
     readonly binaryPrefixable?: true;
 }
 
-const MASS_DIMENSION: Dimensions = new Dimensions([1, 0, 0, 0, 0, 0, 0, 0, 0]);
-const DIST_DIMENSION: Dimensions = new Dimensions([0, 1, 0, 0, 0, 0, 0, 0, 0]);
-const TIME_DIMENSION: Dimensions = new Dimensions([0, 0, 1, 0, 0, 0, 0, 0, 0]);
-const TEMP_DIMENSION: Dimensions = new Dimensions([0, 0, 0, 1, 0, 0, 0, 0, 0]);
+const MASS_DIMENSION: Dimensions = new Dimensions([1, 0, 0, 0, 0, 0, 0, 0]);
+const DIST_DIMENSION: Dimensions = new Dimensions([0, 1, 0, 0, 0, 0, 0, 0]);
+const TIME_DIMENSION: Dimensions = new Dimensions([0, 0, 1, 0, 0, 0, 0, 0]);
+const TEMP_DIMENSION: Dimensions = new Dimensions([0, 0, 0, 1, 0, 0, 0, 0]);
 
-const NRGY_DIMENSIONS: Dimensions = new Dimensions([1, 2, -2, 0, 0, 0, 0, 0, 0]);
-const POWR_DIMENSIONS: Dimensions = new Dimensions([1, 2, -3, 0, 0, 0, 0, 0, 0]);
-const VOLM_DIMENSIONS: Dimensions = new Dimensions([0, 3, 0, 0, 0, 0, 0, 0, 0]);
-const AREA_DIMENSIONS: Dimensions = new Dimensions([0, 2, 0, 0, 0, 0, 0, 0, 0]);
-const INFO_DIMENSIONS: Dimensions = new Dimensions([0, 0, 0, 0, 0, 0, 0, 1, 0]);
-const PRSR_DIMENSIONS: Dimensions = new Dimensions([1, -1, -2, 0, 0, 0, 0, 0, 0]);
+const NRGY_DIMENSIONS: Dimensions = new Dimensions([1, 2, -2, 0, 0, 0, 0, 0]);
+const POWR_DIMENSIONS: Dimensions = new Dimensions([1, 2, -3, 0, 0, 0, 0, 0]);
+const VOLM_DIMENSIONS: Dimensions = new Dimensions([0, 3, 0, 0, 0, 0, 0, 0]);
+const AREA_DIMENSIONS: Dimensions = new Dimensions([0, 2, 0, 0, 0, 0, 0, 0]);
+const INFO_DIMENSIONS: Dimensions = new Dimensions([0, 0, 0, 0, 0, 0, 0, 1]);
+const PRSR_DIMENSIONS: Dimensions = new Dimensions([1, -1, -2, 0, 0, 0, 0, 0]);
 
 /**
  * List of all the units built in to quantity-math-js.
@@ -202,7 +202,7 @@ export const builtInUnits = Object.freeze(
         // "fps": { s: 3.048e-1, d: new Dimensions([0, 1, -1, 0, 0, 0, 0, 0]) },
         // "knot": { s: 5.14444444444444e-1, d: new Dimensions([0, 1, -1, 0, 0, 0, 0, 0]) },
         // "admkn": { s: 5.14773333333333e-1, d: new Dimensions([0, 1, -1, 0, 0, 0, 0, 0]) },
-        "c": { s: 2.99792458e+8, d: new Dimensions([0, 1, -1, 0, 0, 0, 0, 0, 0]) },
+        "c": { s: 2.99792458e+8, d: new Dimensions([0, 1, -1, 0, 0, 0, 0, 0]) },
         // "grav": { s: 9.80665e+0, d: new Dimensions([0, 1, -2, 0, 0, 0, 0, 0]) },
         // "galileo": { s: 1e-2, d: new Dimensions([0, 1, -2, 0, 0, 0, 0, 0]) },
         /** Pascal: SI standard unit for pressure defined as 1 N/m^2 */
@@ -230,7 +230,7 @@ export const builtInUnits = Object.freeze(
         // Force
 
         /** Newtons */
-        "N": { s: 1e+0, d: new Dimensions([1, 1, -2, 0, 0, 0, 0, 0, 0]), prefixable: true },
+        "N": { s: 1e+0, d: new Dimensions([1, 1, -2, 0, 0, 0, 0, 0]), prefixable: true },
         // "dyn": { s: 1e-5, d: new Dimensions([1, 1, -2, 0, 0, 0, 0, 0]) },
         /** Gram Force: the amount of force exerted by standard gravity on a 1 gram mass */
         // "gf": { s: 9.80665e-3, d: new Dimensions([1, 1, -2, 0, 0, 0, 0, 0]) },
@@ -340,37 +340,37 @@ export const builtInUnits = Object.freeze(
         // Electromagnetism
 
         /** Ampere: SI standard unit for electric current, equal to 1 C/s */
-        "A": { s: 1e+0, d: new Dimensions([0, 0, 0, 0, 1, 0, 0, 0, 0]), prefixable: true },
+        "A": { s: 1e+0, d: new Dimensions([0, 0, 0, 0, 1, 0, 0, 0]), prefixable: true },
         /** Coulomb: SI standard unit for electric charge */
-        "C": { s: 1e+0, d: new Dimensions([0, 0, 1, 0, 1, 0, 0, 0, 0]), prefixable: true },
+        "C": { s: 1e+0, d: new Dimensions([0, 0, 1, 0, 1, 0, 0, 0]), prefixable: true },
         /** Amp Hour: Charge collected from 1 Amp over 1 hour */
-        "Ah": { s: 3.6e+3, d: new Dimensions([0, 0, 1, 0, 1, 0, 0, 0, 0]), prefixable: true },
+        "Ah": { s: 3.6e+3, d: new Dimensions([0, 0, 1, 0, 1, 0, 0, 0]), prefixable: true },
         // "e": { s: 1.602176634e-19, d: new Dimensions([0, 0, 1, 0, 1, 0, 0, 0]) },
         /** Volt */
-        "V": { s: 1, d: new Dimensions([1, 2, -3, 0, -1, 0, 0, 0, 0]), prefixable: true },
+        "V": { s: 1, d: new Dimensions([1, 2, -3, 0, -1, 0, 0, 0]), prefixable: true },
         /** Ohm/Ω: Derived SI unit for electrical resistance */
-        "ohm": { s: 1, d: new Dimensions([1, 2, -3, 0, -2, 0, 0, 0, 0]) },
+        "ohm": { s: 1, d: new Dimensions([1, 2, -3, 0, -2, 0, 0, 0]) },
         /** Farad: Derived SI unit of electrical capacitance */
-        "F": { s: 1e+0, d: new Dimensions([-1, -2, 4, 0, 2, 0, 0, 0, 0]), prefixable: true },
+        "F": { s: 1e+0, d: new Dimensions([-1, -2, 4, 0, 2, 0, 0, 0]), prefixable: true },
         /** Henry: Derived SI unit for inductance */
-        "H": { s: 1e+0, d: new Dimensions([1, 2, -2, 0, -2, 0, 0, 0, 0]), prefixable: true },
+        "H": { s: 1e+0, d: new Dimensions([1, 2, -2, 0, -2, 0, 0, 0]), prefixable: true },
         /** Siemens: Derived SI unit for electrical conductance, equal to 1 / ohm */
-        "S": { s: 1e+0, d: new Dimensions([-1, -2, 3, 0, 2, 0, 0, 0, 0]), prefixable: true },
+        "S": { s: 1e+0, d: new Dimensions([-1, -2, 3, 0, 2, 0, 0, 0]), prefixable: true },
         // "mho": { s: 1e+0, d: new Dimensions([-1, -2, 3, 0, 2, 0, 0, 0, 0]) },
         /** Weber: SI unit for magnetic flux defined as 1 kg m^2 / (s^2 A) */
-        "Wb": { s: 1e+0, d: new Dimensions([1, 2, -2, 0, -1, 0, 0, 0, 0]), prefixable: true },
+        "Wb": { s: 1e+0, d: new Dimensions([1, 2, -2, 0, -1, 0, 0, 0]), prefixable: true },
         // "Mx": { s: 1e-8, d: new Dimensions([1, 2, -2, 0, -1, 0, 0, 0, 0]) },
         /** Tesla: SI unit for magnetic flux density defined as 1 Wb / m^2 */
-        "T": { s: 1e+0, d: new Dimensions([1, 0, -2, 0, -1, 0, 0, 0, 0]), prefixable: true },
+        "T": { s: 1e+0, d: new Dimensions([1, 0, -2, 0, -1, 0, 0, 0]), prefixable: true },
         // "Gs": { s: 1e-4, d: new Dimensions([1, 0, -2, 0, -1, 0, 0, 0, 0]) },
         // "gs": { s: 1e-4, d: new Dimensions([1, 0, -2, 0, -1, 0, 0, 0, 0]) },
         // "Fr": { s: 3.3356409519815207e-10, d: new Dimensions([0, 0, 1, 0, 1, 0, 0, 0, 0]) },
         // "Gi": { s: 7.957747e-1, d: new Dimensions([0, 0, 0, 0, 1, 0, 0, 0, 0]) },
         // "Oe": { s: 7.957747154594767e+1, d: new Dimensions([0, -1, 0, 0, 1, 0, 0, 0, 0]) },
         /** Mole: SI standard unit for an amount of substance, defined as exactly 6.02214076e23 elementary entities (usually molecules) */
-        "mol": { s: 1e+0, d: new Dimensions([0, 0, 0, 0, 0, 1, 0, 0, 0]) },
+        "mol": { s: 1e+0, d: new Dimensions([0, 0, 0, 0, 0, 1, 0, 0]) },
         /** Molar Concentration: Amount of substance per Liter of solution */
-        "M": { s: 1e+3, d: new Dimensions([0, -3, 0, 0, 0, 1, 0, 0, 0]) },
+        "M": { s: 1e+3, d: new Dimensions([0, -3, 0, 0, 0, 1, 0, 0]) },
         // "kat": { s: 1e+0, d: new Dimensions([0, 0, -1, 0, 0, 1, 0, 0]) },
         // "U": { s: 1.6666666666666667e-8, d: new Dimensions([0, 0, -1, 0, 0, 1, 0, 0]) },
         /** Candela */
@@ -401,7 +401,7 @@ export const builtInUnits = Object.freeze(
         /** If the non-SI unit rpm is considered a unit of frequency, then 1 rpm = 1/60 Hz (Wikipedia) */
         // "rpm": { s: 1/60, d: new Dimensions([0, 0, -1, 0, 0, 0, 0, 0]) },
         /** Hertz: Frequency defined as 1 (cycle or rotation) / sec */
-        "Hz": { s: 1, d: new Dimensions([0, 0, -1, 0, 0, 0, 0, 0, 0]), prefixable: true },
+        "Hz": { s: 1, d: new Dimensions([0, 0, -1, 0, 0, 0, 0, 0]), prefixable: true },
         // "Bq": { s: 1e+0, d: new Dimensions([0, 0, -1, 0, 0, 0, 0, 0]) },
         // "Gy": { s: 1e+0, d: new Dimensions([0, 2, -2, 0, 0, 0, 0, 0]) },
         // "Sv": { s: 1e+0, d: new Dimensions([0, 2, -2, 0, 0, 0, 0, 0]) },
@@ -415,7 +415,7 @@ export const builtInUnits = Object.freeze(
         /** pphpd: "passengers per hour per direction" (_pax/h⋅_dir) */
         pphpd: {
             s: 1 / 3600,
-            d: new Dimensions([0, 0, -1, 0, 0, 0, 0, 0, 0, -1, 1], ["dir", "pax"]),
+            d: new Dimensions([0, 0, -1, 0, 0, 0, 0, 0, -1, 1], ["dir", "pax"]),
         },
     } as const satisfies Record<string, Unit>,
 );
@@ -577,7 +577,7 @@ export function getUnitData(unit: string, additionalUnits?: Readonly<Record<stri
     if (unit.startsWith("_")) {
         // This is our shorthand notation for the base unit in a custom dimension.
         // e.g. "_pax" is a custom unit with dimensionality of 1 in the "pax" dimension.
-        return { s: 1, d: new Dimensions([0, 0, 0, 0, 0, 0, 0, 0, 0, 1], [unit.substring(1)]) };
+        return { s: 1, d: new Dimensions([0, 0, 0, 0, 0, 0, 0, 0, 1], [unit.substring(1)]) };
     }
     throw new QuantityError(`Unknown/unsupported unit "${unit}"`);
 }

--- a/units.ts
+++ b/units.ts
@@ -572,10 +572,9 @@ export function toUnitString(units: readonly ParsedUnit[]): string {
 }
 
 export function getUnitData(unit: string, additionalUnits?: Readonly<Record<string, Unit>>): Unit {
-    const units: Record<string, Unit> = additionalUnits ? { ...builtInUnits, ...additionalUnits } : builtInUnits;
-    if (unit in units) {
-        return units[unit];
-    } else if (unit.startsWith("_")) {
+    const found: Unit | undefined = builtInUnits[unit as keyof typeof builtInUnits] ?? additionalUnits?.[unit];
+    if (found !== undefined) return found;
+    if (unit.startsWith("_")) {
         // This is our shorthand notation for the base unit in a custom dimension.
         // e.g. "_pax" is a custom unit with dimensionality of 1 in the "pax" dimension.
         return { s: 1, d: new Dimensions([0, 0, 0, 0, 0, 0, 0, 0, 0, 1], [unit.substring(1)]) };

--- a/units.ts
+++ b/units.ts
@@ -420,6 +420,14 @@ export const builtInUnits = Object.freeze(
     } as const satisfies Record<string, Unit>,
 );
 
+/** A unit that the user wants to use. */
+export interface PreferredUnit {
+    /** The SI prefix of this unit, if any. e.g. the "k" (kilo) in "km" (kilometers) */
+    prefix?: Prefix;
+    /** The unit, e.g. "m" for meters or "_pax" for a custom "passengers" unit */
+    unit: string;
+}
+
 /** The result of parsing a unit like "km^2" into its parts (prefix, unit, and power) */
 export interface ParsedUnit {
     /** The SI prefix of this unit, if any. e.g. the "k" (kilo) in "km" (kilometers) */
@@ -431,7 +439,7 @@ export interface ParsedUnit {
 }
 
 /** The base SI units. */
-export const baseSIUnits: ReadonlyArray<Omit<ParsedUnit, "power">> = Object.freeze([
+export const baseSIUnits: readonly PreferredUnit[] = Object.freeze([
     // Base units:
     { unit: "g", prefix: "k" },
     { unit: "m" },
@@ -542,7 +550,7 @@ export function parseUnits(
 /**
  * Convert a parsed unit array, e.g. from parseUnits(), back to a string like "kg⋅m/s^2"
  */
-export function toUnitString(units: ParsedUnit[]): string {
+export function toUnitString(units: readonly ParsedUnit[]): string {
     const numerator: string[] = [];
     const denominator: string[] = [];
     for (const u of units) {


### PR DESCRIPTION
This PR is a fairly significant refactor that:
* greatly improves performance (it now beats all other libraries on the benchmark)
* adds a new `.convert()` API so you can convert to your preferred unit while still getting a `Quantity` object. The previous `.getWithUnits()` API for conversions did not return a `Quantity` object, so was less useful.
* To achieve the improved performance, the (internal) concept of "unit hints" has been replaced with "output unit". This means that each `Quantity` instance remembers what units it was initialized with, and will use those as the default output unit. (Previously only the "hint" of what unit to use was remembered, and this required more computation at each step to determine the actual exact unit to use).
* Removed the unused `luminosity` and `angle` dimensions. Just left one unused `placeholder` dimension for now. You can still add as many custom dimensions as you want.